### PR TITLE
Invert arguments of assertions

### DIFF
--- a/Tests/XCNErrorsTests.m
+++ b/Tests/XCNErrorsTests.m
@@ -16,42 +16,42 @@
 
 - (void)testXCNFileWriteUnknownErrorCreateWithPath {
     NSError *error = XCNFileWriteUnknownErrorCreateWithPath(@"/path/to/file");
-    XCTAssertEqualObjects(XCNErrorDomain, error.domain);
-    XCTAssertEqual(1, error.code);
-    XCTAssertEqualObjects(@"Cannot write at path '/path/to/file'.", error.localizedDescription);
+    XCTAssertEqualObjects(error.domain, XCNErrorDomain);
+    XCTAssertEqual(error.code, 1);
+    XCTAssertEqualObjects(error.localizedDescription, @"Cannot write at path '/path/to/file'.");
     XCTAssertNil(error.localizedFailureReason);
 }
 
 - (void)testXCNIDEFoundationInconsistencyErrorCreateWithFormat {
     NSError *error = XCNIDEFoundationInconsistencyErrorCreateWithFormat(@"%@ %@ %@", @"foo", @"bar", @"baz");
-    XCTAssertEqualObjects(XCNErrorDomain, error.domain);
-    XCTAssertEqual(100, error.code);
-    XCTAssertEqualObjects(@"foo bar baz", error.localizedDescription);
-    XCTAssertEqualObjects(@"This error means Xcode changes interface to manipulate project files.", error.localizedFailureReason);
+    XCTAssertEqualObjects(error.domain, XCNErrorDomain);
+    XCTAssertEqual(error.code, 100);
+    XCTAssertEqualObjects(error.localizedDescription, @"foo bar baz");
+    XCTAssertEqualObjects(error.localizedFailureReason, @"This error means Xcode changes interface to manipulate project files.");
 }
 
 - (void)testXCNInvalidArgumentErrorCreateWithShortOption {
     NSError *error = XCNInvalidArgumentErrorCreateWithShortOption('X');
-    XCTAssertEqualObjects(XCNErrorDomain, error.domain);
-    XCTAssertEqual(110, error.code);
-    XCTAssertEqualObjects(@"Unrecognized option '-X'.", error.localizedDescription);
+    XCTAssertEqualObjects(error.domain, XCNErrorDomain);
+    XCTAssertEqual(error.code, 110);
+    XCTAssertEqualObjects(error.localizedDescription, @"Unrecognized option '-X'.");
     XCTAssertNil(error.localizedFailureReason);
 }
 
 - (void)testXCNInvalidArgumentErrorCreateWithLongOption {
     NSError *error = XCNInvalidArgumentErrorCreateWithLongOption("--invalid");
-    XCTAssertEqualObjects(XCNErrorDomain, error.domain);
-    XCTAssertEqual(110, error.code);
-    XCTAssertEqualObjects(@"Unrecognized option '--invalid'.", error.localizedDescription);
+    XCTAssertEqualObjects(error.domain, XCNErrorDomain);
+    XCTAssertEqual(error.code, 110);
+    XCTAssertEqualObjects(error.localizedDescription, @"Unrecognized option '--invalid'.");
     XCTAssertNil(error.localizedFailureReason);
 }
 
 - (void)testXCNWrongNumberOfArgumentsErrorCreateWithRange {
     NSRange acceptableRangeOfArgumentsCount = NSMakeRange(1, 1);
     NSError *error = XCNWrongNumberOfArgumentsErrorCreateWithRange(acceptableRangeOfArgumentsCount, 4);
-    XCTAssertEqualObjects(XCNErrorDomain, error.domain);
-    XCTAssertEqual(111, error.code);
-    XCTAssertEqualObjects(@"Wrong number of arguments (4 for 1..2).", error.localizedDescription);
+    XCTAssertEqualObjects(error.domain, XCNErrorDomain);
+    XCTAssertEqual(error.code, 111);
+    XCTAssertEqualObjects(error.localizedDescription, @"Wrong number of arguments (4 for 1..2).");
     XCTAssertNil(error.localizedFailureReason);
 }
 

--- a/Tests/XCNOptionSetTests.m
+++ b/Tests/XCNOptionSetTests.m
@@ -33,8 +33,8 @@
     optionSet.language = language;
     optionSet.outputPath = outputPath;
     XCNOptionSet *copied = [optionSet copy];
-    XCTAssertNotEqual(copied, optionSet);
-    XCTAssertEqualObjects(copied, optionSet);
+    XCTAssertNotEqual(optionSet, copied);
+    XCTAssertEqualObjects(optionSet, copied);
 }
 
 @end

--- a/Tests/XCNewTests.m
+++ b/Tests/XCNewTests.m
@@ -46,45 +46,45 @@
 
 - (void)testRunWithNoArguments {
     NSString *stdoutString = nil, *stderrString = nil;
-    XCTAssertEqual(111, [self runWithArguments:@[] standardOutput:&stdoutString standardError:&stderrString]);
-    XCTAssertEqualObjects(@"", stdoutString);
-    XCTAssertEqualObjects(@"xcnew: Wrong number of arguments (0 for 1..2).\n", stderrString);
+    XCTAssertEqual([self runWithArguments:@[] standardOutput:&stdoutString standardError:&stderrString], 111);
+    XCTAssertEqualObjects(stdoutString, @"");
+    XCTAssertEqualObjects(stderrString, @"xcnew: Wrong number of arguments (0 for 1..2).\n");
 }
 
 - (void)testRunWithInvalidShortOptionArguments {
     NSString *stdoutString = nil, *stderrString = nil;
-    XCTAssertEqual(110, [self runWithArguments:@[ @"-X" ] standardOutput:&stdoutString standardError:&stderrString]);
-    XCTAssertEqualObjects(@"", stdoutString);
-    XCTAssertEqualObjects(@"xcnew: Unrecognized option '-X'.\n", stderrString);
+    XCTAssertEqual([self runWithArguments:@[ @"-X" ] standardOutput:&stdoutString standardError:&stderrString], 110);
+    XCTAssertEqualObjects(stdoutString, @"");
+    XCTAssertEqualObjects(stderrString, @"xcnew: Unrecognized option '-X'.\n");
 }
 
 - (void)testRunWithInvalidLongOptionArguments {
     NSString *stdoutString = nil, *stderrString = nil;
-    XCTAssertEqual(110, [self runWithArguments:@[ @"--invalid" ] standardOutput:&stdoutString standardError:&stderrString]);
-    XCTAssertEqualObjects(@"", stdoutString);
-    XCTAssertEqualObjects(@"xcnew: Unrecognized option '--invalid'.\n", stderrString);
+    XCTAssertEqual([self runWithArguments:@[ @"--invalid" ] standardOutput:&stdoutString standardError:&stderrString], 110);
+    XCTAssertEqualObjects(stdoutString, @"");
+    XCTAssertEqualObjects(stderrString, @"xcnew: Unrecognized option '--invalid'.\n");
 }
 
 - (void)testRunWithHelp {
     NSString *stdoutString = nil, *stderrString = nil;
-    XCTAssertEqual(0, [self runWithArguments:@[ @"-h" ] standardOutput:&stdoutString standardError:&stderrString]);
+    XCTAssertEqual([self runWithArguments:@[ @"-h" ] standardOutput:&stdoutString standardError:&stderrString], 0);
     XCTAssertTrue([stdoutString containsString:@"Usage"]);
-    XCTAssertEqualObjects(@"", stderrString);
+    XCTAssertEqualObjects(stderrString, @"");
 }
 
 - (void)testRunWithVersion {
     NSString *stdoutString = nil, *stderrString = nil;
-    XCTAssertEqual(0, [self runWithArguments:@[ @"-v" ] standardOutput:&stdoutString standardError:&stderrString]);
+    XCTAssertEqual([self runWithArguments:@[ @"-v" ] standardOutput:&stdoutString standardError:&stderrString], 0);
     XCTAssertTrue([stdoutString containsString:@"."]);
-    XCTAssertEqualObjects(@"", stderrString);
+    XCTAssertEqualObjects(stderrString, @"");
 }
 
 - (void)testExecuteWithMinimalValidArguments {
     NSString *stdoutString = nil;
     NSString *path = @"Example";
     NSArray *arguments = @[ @"Example" ];
-    XCTAssertEqual(0, [self runWithArguments:arguments standardOutput:&stdoutString standardError:nil]);
-    XCTAssertEqualObjects(@"", stdoutString);
+    XCTAssertEqual([self runWithArguments:arguments standardOutput:&stdoutString standardError:nil], 0);
+    XCTAssertEqualObjects(stdoutString, @"");
     XCNAssertDirectoryExistsAtPath(path);
     NSLog(@"%@", [_fileManager contentsOfDirectoryAtPath:path error:nil]);
     XCNAssertFileOrDirectoryDoesNotExistAtPath([path stringByAppendingPathComponent:@".git/"]);
@@ -110,8 +110,8 @@
                             @"ProductName",
                             path ];
     path = [_fileManager.currentDirectoryPath stringByAppendingPathComponent:path].stringByStandardizingPath;
-    XCTAssertEqual(0, [self runWithArguments:arguments standardOutput:&stdoutString standardError:nil]);
-    XCTAssertEqualObjects(@"", stdoutString);
+    XCTAssertEqual([self runWithArguments:arguments standardOutput:&stdoutString standardError:nil], 0);
+    XCTAssertEqualObjects(stdoutString, @"");
     XCNAssertDirectoryExistsAtPath(path);
     NSLog(@"%@", [_fileManager contentsOfDirectoryAtPath:path error:nil]);
     XCNAssertFileOrDirectoryDoesNotExistAtPath([path stringByAppendingPathComponent:@".git/"]);
@@ -136,8 +136,8 @@
         return XCTFail(@"%@", error);
     }
     NSArray *arguments = @[ @"ProductName", path ];
-    XCTAssertEqual(1, [self runWithArguments:arguments standardOutput:&stdoutString standardError:nil]);
-    XCTAssertEqualObjects(@"", stdoutString);
+    XCTAssertEqual([self runWithArguments:arguments standardOutput:&stdoutString standardError:nil], 1);
+    XCTAssertEqualObjects(stdoutString, @"");
     XCNAssertDirectoryExistsAtPath(path);
     NSLog(@"%@", [_fileManager contentsOfDirectoryAtPath:path error:nil]);
     XCNAssertFileOrDirectoryDoesNotExistAtPath([path stringByAppendingPathComponent:@".git/"]);


### PR DESCRIPTION
Like [Apple does](https://github.com/apple/swift-driver/blob/e1e26c382a3a961cee6ce56a91554ed95473131f/Tests/SwiftDriverTests/TripleTests.swift#L18).

```python
import fileinput
import glob
import re

assertion_re = re.compile(r'^(.*)XCTAssert(|Not)Equal(|Objects)\(([^,]+),\s*(.+)\)(.*)$')
files = glob.glob('./Tests/*.m')

for line in fileinput.input(files, inplace=True):
    matched = assertion_re.search(line)
    if matched is not None:
        print('{0}XCTAssert{1}Equal{2}({4}, {3}){5}'.format(*matched.groups()))
    else:
        print(line.rstrip())
```