### PR TITLE
Use URL instead of string path if possible

### DIFF
--- a/Sources/XCNOptionParser.m
+++ b/Sources/XCNOptionParser.m
@@ -86,11 +86,11 @@
     switch (numberOfRestArguments) {
         case 2:
             optionSet.productName = @(argv[optind]);
-            optionSet.outputPath = @(argv[optind + 1]);
+            optionSet.outputURL = [NSURL fileURLWithPath:@(argv[optind + 1])];
             break;
         case 1:
             optionSet.productName = @(argv[optind]);
-            optionSet.outputPath = optionSet.productName;
+            optionSet.outputURL = [NSURL fileURLWithPath:optionSet.productName];
             break;
         default:
             if (error) {

--- a/Sources/XCNOptionSet.h
+++ b/Sources/XCNOptionSet.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL useCoreData;
 @property (nonatomic) XCNLanguage language;
 @property (nonatomic) XCNUserInterface userInterface;
-@property (nonatomic, copy) NSString *outputPath;
+@property (nonatomic, copy) NSURL *outputURL;
 
 - (BOOL)isEqualToOptionSet:(XCNOptionSet *)optionSet;
 

--- a/Sources/XCNOptionSet.m
+++ b/Sources/XCNOptionSet.m
@@ -30,7 +30,7 @@
             (_useCoreData == optionSet.useCoreData) &&
             (_language == optionSet.language) &&
             (_userInterface == optionSet.userInterface) &&
-            [_outputPath isEqualToString:optionSet.outputPath]);
+            [_outputURL isEqual:optionSet.outputURL]);
 }
 
 - (BOOL)isEqual:(id)object {
@@ -52,7 +52,7 @@
             _useCoreData ^
             _language ^
             _userInterface ^
-            _outputPath.hash);
+            _outputURL.hash);
 }
 
 // MARK: NSCopying
@@ -67,7 +67,7 @@
     copied.useCoreData = _useCoreData;
     copied.language = _language;
     copied.userInterface = _userInterface;
-    copied.outputPath = _outputPath;
+    copied.outputURL = _outputURL;
     return copied;
 }
 

--- a/Sources/XCNProject.h
+++ b/Sources/XCNProject.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithProductName:(NSString *)productName NS_DESIGNATED_INITIALIZER;
-- (BOOL)writeToFile:(NSString *)path error:(NSError *__autoreleasing _Nullable *)error;
+- (BOOL)writeToURL:(NSURL *)url error:(NSError *__autoreleasing _Nullable *)error;
 
 @end
 

--- a/Sources/XCNProject.m
+++ b/Sources/XCNProject.m
@@ -39,15 +39,14 @@
     return self;
 }
 
-- (BOOL)writeToFile:(NSString *)path error:(NSError *__autoreleasing _Nullable *)error {
-    NSParameterAssert(path != nil);
-    path = [self absolutePathForPath:path];
-    if (![_fileManager createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:error]) {
+- (BOOL)writeToURL:(NSURL *)url error:(NSError *__autoreleasing  _Nullable *)error {
+    NSParameterAssert(url != nil);
+    if (![_fileManager createDirectoryAtURL:url withIntermediateDirectories:YES attributes:nil error:error]) {
         return NO;
     }
-    if (![_fileManager isWritableFileAtPath:path]) {
+    if (![_fileManager isWritableFileAtPath:url.path]) {
         if (error) {
-            *error = XCNFileWriteUnknownErrorCreateWithPath(path);
+            *error = XCNFileWriteUnknownErrorCreateWithPath(url.path);
         }
         return NO;
     }
@@ -68,7 +67,7 @@
     [self configureTemplateOptions:template.templateOptions];
     IDETemplateInstantiationContext *context = [kind newTemplateInstantiationContext];
     context.documentTemplate = template;
-    context.documentFilePath = [DVTFilePath filePathForPathString:path];
+    context.documentFilePath = [DVTFilePath filePathForFileURL:url];
     CFRunLoopRef runLoop = CFRunLoopGetCurrent();
     [kind.factory instantiateTemplateForContext:context
                                         options:nil
@@ -94,13 +93,6 @@ static NSString *const kXcode3ProjectTemplateKindIdentifier = @"Xcode.Xcode3.Pro
         }
     }
     return nil;
-}
-
-- (NSString *)absolutePathForPath:(NSString *)path {
-    if (!path.isAbsolutePath) {
-        path = [_fileManager.currentDirectoryPath stringByAppendingPathComponent:path];
-    }
-    return path.stringByStandardizingPath;
 }
 
 - (void)configureTemplateOptions:(NSArray<IDETemplateOption *> *)options {

--- a/Sources/main.m
+++ b/Sources/main.m
@@ -25,7 +25,7 @@ int main(int argc, char *const argv[]) {
             project.useCoreData = optionSet.useCoreData;
             project.language = optionSet.language;
             project.userInterface = optionSet.userInterface;
-            [project writeToFile:optionSet.outputPath error:&error];
+            [project writeToURL:optionSet.outputURL error:&error];
         }
         if (error) {
             NSMutableString *message = [NSMutableString stringWithFormat:@"xcnew: %@", error.localizedDescription];

--- a/Tests/XCNOptionSetTests.m
+++ b/Tests/XCNOptionSetTests.m
@@ -23,7 +23,7 @@
     BOOL useCoreData = YES;
     XCNLanguage language = XCNLanguageObjectiveC;
     XCNUserInterface userInterface = XCNUserInterfaceSwiftUI;
-    NSString *outputPath = @"/test";
+    NSURL *outputURL = [NSURL fileURLWithPath:@"/test"];
     XCNOptionSet *optionSet = [[XCNOptionSet alloc] init];
     optionSet.productName = productName;
     optionSet.organizationName = organizationName;
@@ -33,7 +33,7 @@
     optionSet.useCoreData = useCoreData;
     optionSet.language = language;
     optionSet.userInterface = userInterface;
-    optionSet.outputPath = outputPath;
+    optionSet.outputURL = outputURL;
     XCNOptionSet *copied = [optionSet copy];
     XCTAssertNotEqual(optionSet, copied);
     XCTAssertEqualObjects(optionSet, copied);


### PR DESCRIPTION
https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/AccessingFilesandDirectories/AccessingFilesandDirectories.html#//apple_ref/doc/uid/TP40010672-CH3-SW1

> ## Specifying the Path to a File or Directory
> The preferred way to specify the location of a file or directory is to use the NSURL class. Although the NSString class has many methods related to path creation, URLs offer a more robust way to locate files and directories.