### PR TITLE
Fix unexpected enablement of CoreData

### DIFF
--- a/Sources/xcnew/XCNOptionParser.m
+++ b/Sources/xcnew/XCNOptionParser.m
@@ -57,6 +57,7 @@ static XCNOptionParser *_sharedOptionParser;
             case 't':
 #if XCN_TEST_OPTION_IS_UNIFIED
                 optionSet.feature |= (XCNProjectFeatureUnitTests | XCNProjectFeatureUITests);
+                break;
 #else
                 optionSet.feature |= XCNProjectFeatureUnitTests;
                 break;

--- a/Tests/xcnew-tests/XCNOptionParserParameterizedTests.m
+++ b/Tests/xcnew-tests/XCNOptionParserParameterizedTests.m
@@ -88,38 +88,37 @@ static NSArray<NSInvocation *> *_testInvocations;
                               }],
             [self invocationWithArguments:@[ @"xcnew", @"-t", @"Example" ]
                               expectation:^(XCNOptionSet *optionSet, NSString *output, NSError *error) {
-                                  XCTAssertEqual(optionSet.feature & XCNProjectFeatureUnitTests, XCNProjectFeatureUnitTests);
+                                  XCTAssertEqual(optionSet.feature, XCNProjectFeatureUnitTests | XCNProjectFeatureUITests);
                                   XCTAssertEqualObjects(output, @"");
                                   XCTAssertNil(error);
                               }],
             [self invocationWithArguments:@[ @"xcnew", @"--has-tests", @"Example" ]
                               expectation:^(XCNOptionSet *optionSet, NSString *output, NSError *error) {
-                                  XCTAssertEqual(optionSet.feature & XCNProjectFeatureUnitTests | XCNProjectFeatureUITests,
-                                                 XCNProjectFeatureUnitTests | XCNProjectFeatureUITests);
+                                  XCTAssertEqual(optionSet.feature, XCNProjectFeatureUnitTests | XCNProjectFeatureUITests);
                                   XCTAssertEqualObjects(output, @"");
                                   XCTAssertNil(error);
                               }],
             [self invocationWithArguments:@[ @"xcnew", @"-c", @"Example" ]
                               expectation:^(XCNOptionSet *optionSet, NSString *output, NSError *error) {
-                                  XCTAssertEqual(optionSet.feature & XCNProjectFeatureCoreData, XCNProjectFeatureCoreData);
+                                  XCTAssertEqual(optionSet.feature, XCNProjectFeatureCoreData);
                                   XCTAssertEqualObjects(output, @"");
                                   XCTAssertNil(error);
                               }],
             [self invocationWithArguments:@[ @"xcnew", @"--use-core-data", @"Example" ]
                               expectation:^(XCNOptionSet *optionSet, NSString *output, NSError *error) {
-                                  XCTAssertEqual(optionSet.feature & XCNProjectFeatureCoreData, XCNProjectFeatureCoreData);
+                                  XCTAssertEqual(optionSet.feature, XCNProjectFeatureCoreData);
                                   XCTAssertEqualObjects(output, @"");
                                   XCTAssertNil(error);
                               }],
             [self invocationWithArguments:@[ @"xcnew", @"-C", @"Example" ]
                               expectation:^(XCNOptionSet *optionSet, NSString *output, NSError *error) {
-                                  XCTAssertEqual(optionSet.feature & XCNProjectFeatureCloudKit, XCNProjectFeatureCloudKit);
+                                  XCTAssertEqual(optionSet.feature, XCNProjectFeatureCloudKit);
                                   XCTAssertEqualObjects(output, @"");
                                   XCTAssertNil(error);
                               }],
             [self invocationWithArguments:@[ @"xcnew", @"--use-cloud-kit", @"Example" ]
                               expectation:^(XCNOptionSet *optionSet, NSString *output, NSError *error) {
-                                  XCTAssertEqual(optionSet.feature & XCNProjectFeatureCloudKit, XCNProjectFeatureCloudKit);
+                                  XCTAssertEqual(optionSet.feature, XCNProjectFeatureCloudKit);
                                   XCTAssertEqualObjects(output, @"");
                                   XCTAssertNil(error);
                               }],

--- a/xcnew.xcodeproj/project.pbxproj
+++ b/xcnew.xcodeproj/project.pbxproj
@@ -736,6 +736,10 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.manicmaniac.xcnew;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wimplicit-fallthrough",
+				);
 			};
 			name = Debug;
 		};
@@ -753,6 +757,10 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.manicmaniac.xcnew;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wimplicit-fallthrough",
+				);
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Missing `break` statement causes unexpected enablement of CoreData.

- Add tests for checking flags correctly set
- Add missing `break` statement
- Enable `-Wimplicit-fallthough` to detect such cases