### PR TITLE
Support Xcode 13.4.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: ["13.3.1", "13.2.1", "13.1", "13.0", "12.5"]
+        xcode: ["13.4.1", "13.3.1", "13.2.1", "13.1", "13.0", "12.5"]
         include:
+        - macos: macOS-12
+          xcode: "13.4.1"
         - macos: macOS-12
           xcode: "13.3.1"
         - macos: macOS-11

--- a/Frameworks/.versions
+++ b/Frameworks/.versions
@@ -1,7 +1,7 @@
 + xcodebuild -version
-Xcode 13.3.1
-Build version 13E500a
+Xcode 13.4.1
+Build version 13F100
 + class-dump --version
-class-dump 3.5-0.1.1 (64 bit) (forked by @manicmaniac) compiled Aug  4 2022 13:22:21
+class-dump 3.5-0.1.1 (64 bit) (forked by @manicmaniac) compiled Aug  5 2022 02:36:07
 + clang-format --version
-clang-format version 11.1.0
+clang-format version 14.0.6

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Usage
 Supported Xcode versions
 ------------------------
 
-`Xcode >= 12.5 && Xcode <= 13.3.1`.
+`Xcode >= 12.5 && Xcode <= 13.4.1`.
 
 How it works?
 -------------


### PR DESCRIPTION
Add Xcode 13.4.1 to test targets.

See https://developer.apple.com/documentation/xcode-release-notes for Xcode release notes.

This pull request is created by [`Update Xcode` workflow](https://github.com/manicmaniac/xcnew/blob/master/.github/workflows/update-xcode.yml).