### PR TITLE
Revert "Unifdef on update-xcode"

### DIFF
--- a/Scripts/update-xcode
+++ b/Scripts/update-xcode
@@ -2,7 +2,6 @@
 
 import json
 import re
-import subprocess
 import sys
 from urllib.parse import quote, unquote
 
@@ -67,20 +66,6 @@ class Readme(object):
         return contents
 
 
-def unifdef_source_files(xcode_version):
-    major = xcode_version.split('.')[0]
-    args = [
-        'find', '.',
-        '-type', 'f',
-        '-name', '*.[hm]',
-        '-exec', 'unifdef',
-        f'-DXCODE_VERSION_MAJOR=0x{major}00',
-        '-o', '{}',
-        '{}', ';'
-    ]
-    subprocess.check_call(args)
-
-
 if __name__ == '__main__':
     if len(sys.argv) != 3:
         print(f'usage: {sys.argv[0]} <XCODE_VERSION> <RUNNER>')
@@ -104,5 +89,3 @@ if __name__ == '__main__':
     readme.max_xcode_version = current_xcode_version
     with open(readme_path, 'w') as f:
         f.write(str(readme))
-
-    unifdef_source_files(current_xcode_version)

--- a/Sources/xcnew/XCNMacroDefinitions.h
+++ b/Sources/xcnew/XCNMacroDefinitions.h
@@ -18,8 +18,6 @@
 // Since some versions of Xcode has an invalid octal version number like 0900 and it causes a compilation error,
 // I added prefix `0x` to the actual XCODE_VERSION_MAJOR build variable.
 // See also `Preprocessor Macros` section in the project's build settings.
-#if XCODE_VERSION_MAJOR >= 0x1300
-#define XCN_INFOPLIST_GENERATION_IS_AVAILABLE
-#endif
+#define XCN_INFOPLIST_GENERATION_IS_AVAILABLE (XCODE_VERSION_MAJOR >= 0x1300)
 
 #endif /* XCNMacroDefinions_h */

--- a/Tests/xcnew-integration-tests/XCNewTests.m
+++ b/Tests/xcnew-integration-tests/XCNewTests.m
@@ -97,11 +97,7 @@
     NSArray *arguments = @[ @"-t", productName ];
     XCTAssertEqual([self runWithArguments:arguments output:&outputString error:&errorString], 0);
     XCTAssertEqualObjects(outputString, @"");
-#if XCODE_VERSION_MAJOR >= 0x1300
-    NSString *specificationName = @"Fixtures/tests";
-#else
-    NSString *specificationName = @"Fixtures/tests@xcode12";
-#endif
+    NSString *specificationName = (XCODE_VERSION_MAJOR >= 0x1300 ? @"Fixtures/tests" : @"Fixtures/tests@xcode12");
     XCNAssertFileHierarchyEqualsToSpecificationName(_currentDirectoryURL, specificationName);
 }
 
@@ -147,11 +143,7 @@
     NSArray *arguments = @[ @"-S", productName ];
     XCTAssertEqual([self runWithArguments:arguments output:&outputString error:&errorString], 0);
     XCTAssertEqualObjects(outputString, @"");
-#if XCODE_VERSION_MAJOR >= 0x1300
-    NSString *specificationName = @"Fixtures/swift-ui-lifecycle";
-#else
-    NSString *specificationName = @"Fixtures/swift-ui-lifecycle@xcode12";
-#endif
+    NSString *specificationName = (XCODE_VERSION_MAJOR >= 0x1300 ? @"Fixtures/swift-ui-lifecycle" : @"Fixtures/swift-ui-lifecycle@xcode12");
     XCNAssertFileHierarchyEqualsToSpecificationName(_currentDirectoryURL, specificationName);
 }
 

--- a/Tests/xcnew-tests/XCNProjectTests.m
+++ b/Tests/xcnew-tests/XCNProjectTests.m
@@ -98,10 +98,10 @@ static NSString *const kProductName = @"Example";
     XCTAssertTrue(self.fileWrapper.fileWrappers[@"Example"].fileWrappers[@"Base.lproj"].fileWrappers[@"Main.storyboard"].isRegularFile);
     XCTAssertNil(self.fileWrapper.fileWrappers[@".git"]);
     XCTAssertNil(self.fileWrapper.fileWrappers[@"Example"].fileWrappers[@"Example.xcdatamodeld"]);
-#ifndef XCN_INFOPLIST_GENERATION_IS_AVAILABLE
+#if !XCN_INFOPLIST_GENERATION_IS_AVAILABLE
     XCTAssertTrue(self.fileWrapper.fileWrappers[@"ExampleTests"].fileWrappers[@"Info.plist"].isRegularFile);
     XCTAssertTrue(self.fileWrapper.fileWrappers[@"ExampleUITests"].fileWrappers[@"Info.plist"].isRegularFile);
-#endif // XCN_INFOPLIST_GENERATION_IS_AVAILABLE
+#endif // !XCN_INFOPLIST_GENERATION_IS_AVAILABLE
 }
 
 - (void)testWriteToURLWithCoreData {
@@ -225,9 +225,9 @@ static NSString *const kProductName = @"Example";
     XCTAssertTrue([_project writeToURL:_url timeout:10 error:&error]);
     XCTAssertNil(error);
     XCTAssertTrue(self.fileWrapper.fileWrappers[@"Example.xcodeproj"].fileWrappers[@"project.pbxproj"].isRegularFile);
-#ifndef XCN_INFOPLIST_GENERATION_IS_AVAILABLE
+#if !XCN_INFOPLIST_GENERATION_IS_AVAILABLE
     XCTAssertTrue(self.fileWrapper.fileWrappers[@"Example"].fileWrappers[@"Info.plist"].isRegularFile);
-#endif // XCN_INFOPLIST_GENERATION_IS_AVAILABLE
+#endif // !XCN_INFOPLIST_GENERATION_IS_AVAILABLE
     XCTAssertNil(self.fileWrapper.fileWrappers[@"Example"].fileWrappers[@"AppDelegate.m"]);
     XCTAssertNil(self.fileWrapper.fileWrappers[@"Example"].fileWrappers[@"AppDelegate.swift"]);
     XCTAssertTrue(self.fileWrapper.fileWrappers[@"Example"].fileWrappers[@"ExampleApp.swift"].isRegularFile);


### PR DESCRIPTION
- Revert "Unifdef source files"
- Revert "Unroll #if macros to make them easy to be processed by program"
