### PR TITLE
Use apt instead of apt-get

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       id: install-dependencies
-      run: sudo apt install -y clang-format-12 flake8 shellcheck libxml2-utils
+      run: sudo apt-get install -y clang-format-12 flake8 shellcheck libxml2-utils
     - name: Lint Objective-C files
       if: ${{ always() && steps.install-dependencies.conclusion == 'success' }}
       run: git ls-files -z '*.[hm]' | xargs -0 clang-format --dry-run --Werror


### PR DESCRIPTION
Fix https://github.com/manicmaniac/xcnew/actions/runs/2928681991/jobs/4673128603
> WARNING: apt does not have a stable CLI interface. Use with caution in scripts.