### PR TITLE
Support Xcode 14.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: ["13.4.1", "13.3.1", "13.2.1", "13.1", "13.0", "12.5"]
+        xcode: ["14.1.0", "13.4.1", "13.3.1", "13.2.1", "13.1", "13.0", "12.5"]
         include:
+        - macos: macOS-12
+          xcode: "14.1.0"
         - macos: macOS-12
           xcode: "13.4.1"
         - macos: macOS-12

--- a/Frameworks/.versions
+++ b/Frameworks/.versions
@@ -1,7 +1,7 @@
 + xcodebuild -version
-Xcode 13.4.1
-Build version 13F100
+Xcode 14.1
+Build version 14B47b
 + class-dump --version
-class-dump 3.5-0.1.1 (64 bit) (forked by @manicmaniac) compiled Aug 16 2022 11:43:02
+class-dump 3.5-0.1.1 (64 bit) (forked by @manicmaniac) compiled Nov 18 2022 05:45:45
 + clang-format --version
 clang-format version 14.0.6

--- a/Frameworks/DVTFoundation.framework/Versions/A/Headers/DVTPlatform.h
+++ b/Frameworks/DVTFoundation.framework/Versions/A/Headers/DVTPlatform.h
@@ -7,12 +7,15 @@
 #import <Foundation/Foundation.h>
 
 
-@class DVTExtendedPlatformInfo, DVTFilePath, DVTPlatformFamily, DVTVersion, NSArray, NSDictionary, NSHashTable, NSSet, NSString;
+@class DVTExtendedPlatformInfo, DVTFilePath, DVTPlatformFamily, DVTSDK, DVTVersion, NSArray, NSDictionary, NSHashTable, NSSet, NSString, _TtC13DVTFoundation16DVTKnownPlatform;
 
 @interface DVTPlatform : NSObject<NSCopying>
 
-+ (id)_preferredArchitectureForPlatformWithIdentifier:(id)arg1;
 + (id)extraPlatformFolders;
++ (id)onlyLoadPlatformFamilyNames;
++ (id)onlyLoadPlatformIdentifiers;
++ (BOOL)onlySearchExtraPlatformFolders;
++ (BOOL)allowMissingDefaultPlatform;
 + (id)defaultPlatform;
 + (BOOL)validatePlatformDataReturningError:(id *)arg1;
 + (BOOL)loadAllPlatformsReturningError:(id *)arg1;
@@ -38,17 +41,22 @@
 @property (readonly) DVTFilePath *platformPath;             // @synthesize platformPath=_platformPath;
 @property (readonly, copy) NSString *platformDirectoryName; // @synthesize platformDirectoryName=_platformDirectoryName;
 @property (readonly) DVTVersion *minimumSDKVersion;         // @synthesize minimumSDKVersion=_minimumSDKVersion;
-@property (readonly) DVTPlatformFamily *family;             // @synthesize family=_family;
+@property (retain) DVTPlatformFamily *family;               // @synthesize family=_family;
 @property (readonly, copy) NSString *name;                  // @synthesize name=_name;
 @property (readonly, copy) NSArray *alternateNames;         // @synthesize alternateNames=_alternateNames;
 @property (readonly, copy) NSString *identifier;            // @synthesize identifier=_identifier;
+@property (readonly) BOOL isiOSDevice;
+@property (readonly) BOOL isWatchDevice;
+@property (readonly) BOOL isWatchPlatform;
 - (id)copyWithZone:(struct _NSZone *)arg1;
 - (unsigned long long)hash;
 - (BOOL)isEqual:(id)arg1;
 - (id)description;
 @property (readonly, copy) NSString *internalSDKName;
 @property (readonly, copy) NSString *sdkName;
+- (id)mappedOperatingSystemVersionForPlatformFamilyName:(id)arg1 version:(id)arg2;
 - (id)mappedOperatingSystemVersionForPlatformFamily:(id)arg1 version:(id)arg2;
+@property (readonly) DVTSDK *defaultSDKForPlatformInstallation;
 @property (readonly, copy) NSSet *SDKs;
 - (void)addSDK:(id)arg1;
 - (id)internalPropertyListDictionary;
@@ -57,5 +65,9 @@
 - (id)initWithPropertyListDictionary:(id)arg1 path:(id)arg2;
 - (id)dvt_extendedInfoOrError:(id *)arg1;
 @property (readonly) DVTExtendedPlatformInfo *dvt_extendedInfo;
+@property (nonatomic, readonly) DVTSDK *latestInternalOrPublicSDK;
+@property (nonatomic, readonly) DVTSDK *latestPublicOrInternalSDK;
+@property (nonatomic, readonly) NSArray *allSupportedArchitectures;
+@property (nonatomic, readonly) _TtC13DVTFoundation16DVTKnownPlatform *knownPlatform;
 
 @end

--- a/Frameworks/IDEFoundation.framework/Versions/A/Headers/IDETemplate.h
+++ b/Frameworks/IDEFoundation.framework/Versions/A/Headers/IDETemplate.h
@@ -24,6 +24,7 @@
 + (void)initialize;
 + (id)_templateInfoForTemplateAtURL:(id)arg1 error:(id *)arg2;
 // - (void).cxx_destruct;
+@property BOOL skipOptionsAssistant;                               // @synthesize skipOptionsAssistant=_skipOptionsAssistant;
 @property (retain) IDETemplateOption *optionWithAllowedTypes;      // @synthesize optionWithAllowedTypes=_optionWithAllowedTypes;
 @property (retain) IDETemplateOption *optionWithMainTemplateFiles; // @synthesize optionWithMainTemplateFiles=_optionWithMainTemplateFiles;
 @property BOOL isDebug;                                            // @synthesize isDebug=_isDebug;

--- a/Frameworks/IDEFoundation.framework/Versions/A/Headers/IDETemplateOption.h
+++ b/Frameworks/IDEFoundation.framework/Versions/A/Headers/IDETemplateOption.h
@@ -13,6 +13,7 @@
 
 + (id)keyPathsForValuesAffectingBooleanValue;
 + (id)keyPathsForValuesAffectingDisplayValues;
++ (id)keyPathsForValuesAffectingAssistantWarningString;
 + (id)keyPathsForValuesAffectingHasValidValue;
 + (id)keyPathsForValuesAffectingDisplayValue;
 + (id)allowedTemplateOptionTypes;
@@ -21,6 +22,7 @@
 @property (nonatomic) BOOL disabledByConstraints;                   // @synthesize disabledByConstraints=_disabledByConstraints;
 @property (nonatomic) BOOL enabled;                                 // @synthesize enabled=_enabled;
 @property (nonatomic) BOOL indented;                                // @synthesize indented=_indented;
+@property (nonatomic) BOOL warnForProblematicProductNames;          // @synthesize warnForProblematicProductNames=_warnForProblematicProductNames;
 @property long long sortOrder;                                      // @synthesize sortOrder=_sortOrder;
 @property (readonly) NSDictionary *variables;                       // @synthesize variables=_variables;
 @property (readonly) NSDictionary *allowedTypes;                    // @synthesize allowedTypes=_allowedTypes;
@@ -51,6 +53,7 @@
 - (void)updateFilteredDisplayValuesWithOptions:(id)arg1;
 @property (readonly) NSArray *displayValues;
 @property (readonly) BOOL hasExplicitValues;
+@property (readonly) NSString *assistantWarningString;
 @property (readonly) BOOL hasValidValue;
 - (void)updateValueWithBuildables:(id)arg1;
 - (void)updateValueWithOptions:(id)arg1;

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ xcnew
 
 [![GitHub Actions](https://github.com/manicmaniac/xcnew/actions/workflows/test.yml/badge.svg)](https://github.com/manicmaniac/xcnew/actions/workflows/test.yml)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/1b708551a78044461357/test_coverage)](https://codeclimate.com/github/manicmaniac/xcnew/test_coverage)
-[![Xcode](https://img.shields.io/badge/xcode-12%20%7C%2013-blue)](https://github.com/manicmaniac/xcnew#supported-xcode-versions)
+[![Xcode](https://img.shields.io/badge/xcode-12%20%7C%2013%20%7C%2014-blue)](https://github.com/manicmaniac/xcnew#supported-xcode-versions)
 
 A command line interface to make a project for iOS Single View App.
 
@@ -79,7 +79,7 @@ Usage
 Supported Xcode versions
 ------------------------
 
-`Xcode >= 12.5 && Xcode <= 13.4.1`.
+`Xcode >= 12.5 && Xcode <= 14.1.0`.
 
 How it works?
 -------------

--- a/Tests/xcnew-integration-tests/xcnew-integration-tests.sb
+++ b/Tests/xcnew-integration-tests/xcnew-integration-tests.sb
@@ -3,14 +3,22 @@
 (version 1)
 
 (deny default)
-(allow process-exec
+(allow process-exec*
+    (regex #"XCBBuildService")
     (regex #"xcnew$"))
+(allow process-fork)
 (allow ipc-posix-shm*)
+(allow iokit-open-user-client)
 (allow mach-lookup)
+(allow file-ioctl
+    (literal "/dev/dtracehelper"))
 (allow file-read*)
 (allow file-write*
-    (subpath "/private/var/folders"))
-(allow sysctl-read
-    (sysctl-name "hw.pagesize" "hw.pagesize_compat")
-    (sysctl-name "machdep.cpu.core_count"))
+    (subpath "/private/var/folders")
+    (literal "/dev/dtracehelper")
+    (literal "/dev/null"))
+(allow job-creation)
+(allow sysctl*)
+(allow system-fsctl)
+(allow user-preference-read)
 (allow user-preference-write)

--- a/Tests/xcnew-integration-tests/xcnew-integration-tests.sb
+++ b/Tests/xcnew-integration-tests/xcnew-integration-tests.sb
@@ -9,7 +9,6 @@
     (regex #"xcnew$"))
 (allow process-fork)
 (allow ipc-posix-shm*)
-(allow iokit-open-user-client)
 (allow mach-lookup)
 (allow file-ioctl
     (literal "/dev/dtracehelper"))
@@ -23,3 +22,7 @@
 (allow system-fsctl)
 (allow user-preference-read)
 (allow user-preference-write)
+
+; iokit-open-user-client is not defined in macOS < 12
+(if (defined? 'iokit-open-user-client)
+    (allow iokit-open-user-client))

--- a/Tests/xcnew-integration-tests/xcnew-integration-tests.sb
+++ b/Tests/xcnew-integration-tests/xcnew-integration-tests.sb
@@ -1,4 +1,5 @@
 ; See https://reverse.put.as/wp-content/uploads/2011/09/Apple-Sandbox-Guide-v1.0.pdf for syntax.
+; To see log of sandbox, run `log stream --level error --predicate 'process = "kernel" AND sender = "Sandbox"'`
 
 (version 1)
 


### PR DESCRIPTION
Add Xcode 14.1.0 to test targets.

See https://developer.apple.com/documentation/xcode-release-notes for Xcode release notes.

This pull request is created by [`Update Xcode` workflow](https://github.com/manicmaniac/xcnew/blob/master/.github/workflows/update-xcode.yml).