### PR TITLE
Always run tapi-analyze

### DIFF
--- a/xcnew.xcodeproj/project.pbxproj
+++ b/xcnew.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -487,6 +487,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		5B11B38F2647ADC600653ABF /* Analyze Executable */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
Fix a warning in https://github.com/manicmaniac/xcnew/actions/runs/3490658353/jobs/5842355147

>     Run script build phase 'Analyze Executable' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'xcnew' from project 'xcnew')