### PR TITLE
Ignore known warnings in tests

### DIFF
--- a/Tests/xcnew-integration-tests/XCNSpamWarningSuppressor.h
+++ b/Tests/xcnew-integration-tests/XCNSpamWarningSuppressor.h
@@ -1,0 +1,20 @@
+//
+//  XCNSpamWarningSuppressor.h
+//  xcnew
+//
+//  Created by Ryosuke Ito on 11/18/22.
+//  Copyright © 2022 Ryosuke Ito. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface XCNSpamWarningSuppressor : NSObject
+
+- (instancetype)initWithFileHandle:(NSFileHandle *)fileHandle;
+- (nullable NSString *)readStringToEndOfFileAndReturnError:(NSError *__autoreleasing _Nullable *_Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/xcnew-integration-tests/XCNSpamWarningSuppressor.m
+++ b/Tests/xcnew-integration-tests/XCNSpamWarningSuppressor.m
@@ -1,0 +1,134 @@
+//
+//  XCNSpamWarningSuppressor.m
+//  xcnew
+//
+//  Created by Ryosuke Ito on 11/18/22.
+//  Copyright © 2022 Ryosuke Ito. All rights reserved.
+//
+
+#import "XCNSpamWarningSuppressor.h"
+
+@implementation XCNSpamWarningSuppressor {
+    NSFileHandle *_fileHandle;
+}
+
+// MARK: Public
+
++ (void)initialize {
+    [super initialize];
+    // Instantiate a regular expression as early as possible so that the syntax error can be found earlier.
+    NSError *error;
+    XCNSymbolCollisionWarningRegularExpression = [NSRegularExpression regularExpressionWithPattern:kSymbolCollisionWarningPattern
+                                                                                           options:NSRegularExpressionAnchorsMatchLines
+                                                                                             error:&error];
+    if (!XCNSymbolCollisionWarningRegularExpression) {
+        [NSException raise:NSInvalidArgumentException format:@"%@", error];
+    }
+    XCNWatchOSExtensionPointWarningRegularExpression = [NSRegularExpression regularExpressionWithPattern:kWatchOSExtensionPointWarningPattern
+                                                                                                 options:NSRegularExpressionAnchorsMatchLines
+                                                                                                   error:&error];
+    if (!XCNWatchOSExtensionPointWarningRegularExpression) {
+        [NSException raise:NSInvalidArgumentException format:@"%@", error];
+    }
+    XCNGetSwiftVersionWarningRegularExpression = [NSRegularExpression regularExpressionWithPattern:kGetSwiftVersionWarningPattern
+                                                                                           options:NSRegularExpressionAnchorsMatchLines
+                                                                                             error:&error];
+    if (!XCNGetSwiftVersionWarningRegularExpression) {
+        [NSException raise:NSInvalidArgumentException format:@"%@", error];
+    }
+    XCNXCAssetPermissionErrorRegularExpression = [NSRegularExpression regularExpressionWithPattern:kXCAssetPermissionErrorPattern
+                                                                                           options:NSRegularExpressionAnchorsMatchLines
+                                                                                             error:&error];
+    if (!XCNXCAssetPermissionErrorRegularExpression) {
+        [NSException raise:NSInvalidArgumentException format:@"%@", error];
+    }
+}
+
+- (instancetype)initWithFileHandle:(NSFileHandle *)fileHandle {
+    self = [super init];
+    if (self) {
+        _fileHandle = fileHandle;
+    }
+    return self;
+}
+
+- (NSString *)readStringToEndOfFileAndReturnError:(NSError **)error {
+    NSData *data = [_fileHandle readDataToEndOfFileAndReturnError:error];
+    if (!data) {
+        return nil;
+    }
+    NSMutableString *string = [[NSMutableString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    [XCNSymbolCollisionWarningRegularExpression replaceMatchesInString:string
+                                                               options:(NSMatchingOptions)0
+                                                                 range:NSMakeRange(0, string.length)
+                                                          withTemplate:@""];
+    [XCNWatchOSExtensionPointWarningRegularExpression replaceMatchesInString:string
+                                                                     options:(NSMatchingOptions)0
+                                                                       range:NSMakeRange(0, string.length)
+                                                                withTemplate:@""];
+    [XCNGetSwiftVersionWarningRegularExpression replaceMatchesInString:string
+                                                               options:(NSMatchingOptions)0
+                                                                 range:NSMakeRange(0, string.length)
+                                                          withTemplate:@""];
+    [XCNXCAssetPermissionErrorRegularExpression replaceMatchesInString:string
+                                                               options:(NSMatchingOptions)0
+                                                                 range:NSMakeRange(0, string.length)
+                                                          withTemplate:@""];
+    return string;
+}
+
+// MARK: Private
+
+/**
+ * A regular expression pattern to match and delete spam warnings from Xcode.
+ *
+ * When running Xcode 13 command line tools on Apple Silicon devices,
+ * it warns about symbol collision between libamsupport and MobileDevice.framework.
+ * This could be a bug in Xcode 13 as many developers reported in developer forums or other websites.
+ * Although setting command line tools to /Library/Developer/CommandLineTools may fix the issue,
+ * this solution does not help on CI environment because it needs command line tools set under
+ * Xcode's developer directory.
+ *
+ * - https://developer.apple.com/forums/thread/698628
+ * - https://stackoverflow.com/q/65547989
+ */
+static NSString *const kSymbolCollisionWarningPattern = @"^objc\\[[0-9]+\\]: Class AMSupportURL(ConnectionDelegate|Session) is implemented in both "
+                                                        @"/usr/lib/libamsupport.dylib \\(0x[0-9a-f]+\\) and "
+                                                        @"/Library/Apple/System/Library/PrivateFrameworks/MobileDevice\\.framework/Versions/A/MobileDevice "
+                                                        @"\\(0x[0-9a-f]+\\)\\. One of the two will be used. Which one is undefined.$\\n";
+static NSRegularExpression *XCNSymbolCollisionWarningRegularExpression = nil;
+
+/**
+ * A regular expression pattern to match and delete spam warnings from Xcode.
+ *
+ * When running Xcode 13 command line tools, it warns about missing extension points for watchOS.
+ * I don't know why it occurs but sometimes even `xcodebuild` or other official tools complain the same.
+ *
+ * - https://developer.apple.com/forums/thread/703233
+ */
+static NSString *const kWatchOSExtensionPointWarningPattern = @"^.*Requested but did not find extension point with identifier "
+                                                              @"Xcode\\.IDEKit\\.Extension(SentinelHostApplications|PointIdentifierToBundleIdentifier) "
+                                                              @"for extension Xcode\\.DebuggerFoundation\\.AppExtension.*\\.watchOS of plug-in .*$\\n";
+static NSRegularExpression *XCNWatchOSExtensionPointWarningRegularExpression = nil;
+
+/**
+ * A regular expression pattern to match and delete spam warnings from Xcode.
+ *
+ * When running Xcode 13 command line tools, it warns about failure to get Swift version.
+ * This could be a bug in `xcnew` but currently I have no idea to fix it.
+ */
+static NSString *const kGetSwiftVersionWarningPattern = @"^.*DVTToolchain: Failed to get Swift version for /.*/XcodeDefault.xctoolchain: "
+                                                        @"Error Domain=NSPOSIXErrorDomain Code=1 \"Operation not permitted\"$\\n";
+static NSRegularExpression *XCNGetSwiftVersionWarningRegularExpression = nil;
+
+/**
+ * A regular expression pattern to match and delete spam warnings from Xcode.
+ *
+ * When running Xcode 13 command line tools, it warns about permission to write Assets.xcassets.
+ * This could be a bug in `xcnew` but currently I have no idea to fix it.
+ */
+static NSString *const kXCAssetPermissionErrorPattern = @"^.*Error outputting Assets\\.xcassets: Error Domain=NSPOSIXErrorDomain Code=1 "
+                                                        @"\"Operation not permitted\"$\\n";
+static NSRegularExpression *XCNXCAssetPermissionErrorRegularExpression = nil;
+
+@end

--- a/Tests/xcnew-integration-tests/XCNewTests.m
+++ b/Tests/xcnew-integration-tests/XCNewTests.m
@@ -9,6 +9,7 @@
 #import <XCTest/XCTest.h>
 #import "XCNFileHierarchyAssertions.h"
 #import "XCNMacroDefinitions.h"
+#import "XCNSpamWarningSuppressor.h"
 
 @interface XCNewTests : XCTestCase
 @end
@@ -21,89 +22,7 @@
     NSURL *_sandboxProfileURL;
 }
 
-/**
- * A regular expression pattern to match and delete spam warnings from Xcode.
- *
- * When running Xcode 13 command line tools on Apple Silicon devices,
- * it warns about symbol collision between libamsupport and MobileDevice.framework.
- * This could be a bug in Xcode 13 as many developers reported in developer forums or other websites.
- * Although setting command line tools to /Library/Developer/CommandLineTools may fix the issue,
- * this solution does not help on CI environment because it needs command line tools set under
- * Xcode's developer directory.
- *
- * - https://developer.apple.com/forums/thread/698628
- * - https://stackoverflow.com/q/65547989
- */
-static NSString *const kSymbolCollisionWarningPattern = @"^objc\\[[0-9]+\\]: Class AMSupportURL(ConnectionDelegate|Session) is implemented in both "
-                                                        @"/usr/lib/libamsupport.dylib \\(0x[0-9a-f]+\\) and "
-                                                        @"/Library/Apple/System/Library/PrivateFrameworks/MobileDevice\\.framework/Versions/A/MobileDevice "
-                                                        @"\\(0x[0-9a-f]+\\)\\. One of the two will be used. Which one is undefined.$\\n";
-static NSRegularExpression *XCNSymbolCollisionWarningRegularExpression = nil;
-
-/**
- * A regular expression pattern to match and delete spam warnings from Xcode.
- *
- * When running Xcode 13 command line tools, it warns about missing extension points for watchOS.
- * I don't know why it occurs but sometimes even `xcodebuild` or other official tools complain the same.
- *
- * - https://developer.apple.com/forums/thread/703233
- */
-static NSString *const kWatchOSExtensionPointWarningPattern = @"^.*Requested but did not find extension point with identifier "
-                                                              @"Xcode\\.IDEKit\\.Extension(SentinelHostApplications|PointIdentifierToBundleIdentifier) "
-                                                              @"for extension Xcode\\.DebuggerFoundation\\.AppExtension.*\\.watchOS of plug-in .*$\\n";
-static NSRegularExpression *XCNWatchOSExtensionPointWarningRegularExpression = nil;
-
-/**
- * A regular expression pattern to match and delete spam warnings from Xcode.
- *
- * When running Xcode 13 command line tools, it warns about failure to get Swift version.
- * This could be a bug in `xcnew` but currently I have no idea to fix it.
- */
-static NSString *const kGetSwiftVersionWarningPattern = @"^.*DVTToolchain: Failed to get Swift version for /.*/XcodeDefault.xctoolchain: "
-                                                        @"Error Domain=NSPOSIXErrorDomain Code=1 \"Operation not permitted\"$\\n";
-static NSRegularExpression *XCNGetSwiftVersionWarningRegularExpression = nil;
-
-/**
- * A regular expression pattern to match and delete spam warnings from Xcode.
- *
- * When running Xcode 13 command line tools, it warns about permission to write Assets.xcassets.
- * This could be a bug in `xcnew` but currently I have no idea to fix it.
- */
-static NSString *const kXCAssetPermissionErrorPattern = @"^.*Error outputting Assets\\.xcassets: Error Domain=NSPOSIXErrorDomain Code=1 "
-                                                        @"\"Operation not permitted\"$\\n";
-static NSRegularExpression *XCNXCAssetPermissionErrorRegularExpression = nil;
-
 // MARK: Public
-
-+ (void)initialize {
-    [super initialize];
-    // Instantiate a regular expression as early as possible so that the syntax error can be found earlier.
-    NSError *error;
-    XCNSymbolCollisionWarningRegularExpression = [NSRegularExpression regularExpressionWithPattern:kSymbolCollisionWarningPattern
-                                                                                           options:NSRegularExpressionAnchorsMatchLines
-                                                                                             error:&error];
-    if (!XCNSymbolCollisionWarningRegularExpression) {
-        [NSException raise:NSInvalidArgumentException format:@"%@", error];
-    }
-    XCNWatchOSExtensionPointWarningRegularExpression = [NSRegularExpression regularExpressionWithPattern:kWatchOSExtensionPointWarningPattern
-                                                                                                 options:NSRegularExpressionAnchorsMatchLines
-                                                                                                   error:&error];
-    if (!XCNWatchOSExtensionPointWarningRegularExpression) {
-        [NSException raise:NSInvalidArgumentException format:@"%@", error];
-    }
-    XCNGetSwiftVersionWarningRegularExpression = [NSRegularExpression regularExpressionWithPattern:kGetSwiftVersionWarningPattern
-                                                                                           options:NSRegularExpressionAnchorsMatchLines
-                                                                                             error:&error];
-    if (!XCNGetSwiftVersionWarningRegularExpression) {
-        [NSException raise:NSInvalidArgumentException format:@"%@", error];
-    }
-    XCNXCAssetPermissionErrorRegularExpression = [NSRegularExpression regularExpressionWithPattern:kXCAssetPermissionErrorPattern
-                                                                                           options:NSRegularExpressionAnchorsMatchLines
-                                                                                             error:&error];
-    if (!XCNXCAssetPermissionErrorRegularExpression) {
-        [NSException raise:NSInvalidArgumentException format:@"%@", error];
-    }
-}
 
 - (BOOL)setUpWithError:(NSError *__autoreleasing _Nullable *)error {
     _fileManager = NSFileManager.defaultManager;
@@ -266,38 +185,14 @@ static NSRegularExpression *XCNXCAssetPermissionErrorRegularExpression = nil;
         *outputString = [[NSString alloc] initWithData:outputData encoding:NSUTF8StringEncoding];
     }
     if (errorString) {
-        if (!(*errorString = [self readStringSuppressingLogNoiseFromFileHandle:errorPipe.fileHandleForReading error:&error])) {
+        XCNSpamWarningSuppressor *suppressor = [[XCNSpamWarningSuppressor alloc] initWithFileHandle:errorPipe.fileHandleForReading];
+        if (!(*errorString = [suppressor readStringToEndOfFileAndReturnError:&error])) {
             self.continueAfterFailure = NO;
             XCTFail(@"%@", error);
             return -1;
         }
     }
     return task.terminationStatus;
-}
-
-- (NSString *)readStringSuppressingLogNoiseFromFileHandle:(NSFileHandle *)fileHandle error:(NSError **)error {
-    NSData *data = [fileHandle readDataToEndOfFileAndReturnError:error];
-    if (!data) {
-        return nil;
-    }
-    NSMutableString *string = [[NSMutableString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    [XCNSymbolCollisionWarningRegularExpression replaceMatchesInString:string
-                                                               options:(NSMatchingOptions)0
-                                                                 range:NSMakeRange(0, string.length)
-                                                          withTemplate:@""];
-    [XCNWatchOSExtensionPointWarningRegularExpression replaceMatchesInString:string
-                                                                     options:(NSMatchingOptions)0
-                                                                       range:NSMakeRange(0, string.length)
-                                                                withTemplate:@""];
-    [XCNGetSwiftVersionWarningRegularExpression replaceMatchesInString:string
-                                                               options:(NSMatchingOptions)0
-                                                                 range:NSMakeRange(0, string.length)
-                                                          withTemplate:@""];
-    [XCNXCAssetPermissionErrorRegularExpression replaceMatchesInString:string
-                                                               options:(NSMatchingOptions)0
-                                                                 range:NSMakeRange(0, string.length)
-                                                          withTemplate:@""];
-    return string;
 }
 
 @end

--- a/Tests/xcnew-integration-tests/XCNewTests.m
+++ b/Tests/xcnew-integration-tests/XCNewTests.m
@@ -63,6 +63,16 @@ static NSString *const kGetSwiftVersionWarningPattern = @"^.*DVTToolchain: Faile
                                                         @"Error Domain=NSPOSIXErrorDomain Code=1 \"Operation not permitted\"$\\n";
 static NSRegularExpression *XCNGetSwiftVersionWarningRegularExpression = nil;
 
+/**
+ * A regular expression pattern to match and delete spam warnings from Xcode.
+ *
+ * When running Xcode 13 command line tools, it warns about permission to write Assets.xcassets.
+ * This could be a bug in `xcnew` but currently I have no idea to fix it.
+ */
+static NSString *const kXCAssetPermissionErrorPattern = @"^.*Error outputting Assets\\.xcassets: Error Domain=NSPOSIXErrorDomain Code=1 "
+                                                        @"\"Operation not permitted\"$\\n";
+static NSRegularExpression *XCNXCAssetPermissionErrorRegularExpression = nil;
+
 // MARK: Public
 
 + (void)initialize {
@@ -85,6 +95,12 @@ static NSRegularExpression *XCNGetSwiftVersionWarningRegularExpression = nil;
                                                                                            options:NSRegularExpressionAnchorsMatchLines
                                                                                              error:&error];
     if (!XCNGetSwiftVersionWarningRegularExpression) {
+        [NSException raise:NSInvalidArgumentException format:@"%@", error];
+    }
+    XCNXCAssetPermissionErrorRegularExpression = [NSRegularExpression regularExpressionWithPattern:kXCAssetPermissionErrorPattern
+                                                                                           options:NSRegularExpressionAnchorsMatchLines
+                                                                                             error:&error];
+    if (!XCNXCAssetPermissionErrorRegularExpression) {
         [NSException raise:NSInvalidArgumentException format:@"%@", error];
     }
 }
@@ -274,6 +290,10 @@ static NSRegularExpression *XCNGetSwiftVersionWarningRegularExpression = nil;
                                                                        range:NSMakeRange(0, string.length)
                                                                 withTemplate:@""];
     [XCNGetSwiftVersionWarningRegularExpression replaceMatchesInString:string
+                                                               options:(NSMatchingOptions)0
+                                                                 range:NSMakeRange(0, string.length)
+                                                          withTemplate:@""];
+    [XCNXCAssetPermissionErrorRegularExpression replaceMatchesInString:string
                                                                options:(NSMatchingOptions)0
                                                                  range:NSMakeRange(0, string.length)
                                                           withTemplate:@""];

--- a/Tests/xcnew-integration-tests/XCNewTests.m
+++ b/Tests/xcnew-integration-tests/XCNewTests.m
@@ -53,6 +53,16 @@ static NSString *const kWatchOSExtensionPointWarningPattern = @"^.*Requested but
                                                               @"for extension Xcode\\.DebuggerFoundation\\.AppExtension.*\\.watchOS of plug-in .*$\\n";
 static NSRegularExpression *XCNWatchOSExtensionPointWarningRegularExpression = nil;
 
+/**
+ * A regular expression pattern to match and delete spam warnings from Xcode.
+ *
+ * When running Xcode 13 command line tools, it warns about failure to get Swift version.
+ * This could be a bug in `xcnew` but currently I have no idea to fix it.
+ */
+static NSString *const kGetSwiftVersionWarningPattern = @"^.*DVTToolchain: Failed to get Swift version for /.*/XcodeDefault.xctoolchain: "
+                                                        @"Error Domain=NSPOSIXErrorDomain Code=1 \"Operation not permitted\"$\\n";
+static NSRegularExpression *XCNGetSwiftVersionWarningRegularExpression = nil;
+
 // MARK: Public
 
 + (void)initialize {
@@ -69,6 +79,12 @@ static NSRegularExpression *XCNWatchOSExtensionPointWarningRegularExpression = n
                                                                                                  options:NSRegularExpressionAnchorsMatchLines
                                                                                                    error:&error];
     if (!XCNWatchOSExtensionPointWarningRegularExpression) {
+        [NSException raise:NSInvalidArgumentException format:@"%@", error];
+    }
+    XCNGetSwiftVersionWarningRegularExpression = [NSRegularExpression regularExpressionWithPattern:kGetSwiftVersionWarningPattern
+                                                                                           options:NSRegularExpressionAnchorsMatchLines
+                                                                                             error:&error];
+    if (!XCNGetSwiftVersionWarningRegularExpression) {
         [NSException raise:NSInvalidArgumentException format:@"%@", error];
     }
 }
@@ -257,6 +273,10 @@ static NSRegularExpression *XCNWatchOSExtensionPointWarningRegularExpression = n
                                                                      options:(NSMatchingOptions)0
                                                                        range:NSMakeRange(0, string.length)
                                                                 withTemplate:@""];
+    [XCNGetSwiftVersionWarningRegularExpression replaceMatchesInString:string
+                                                               options:(NSMatchingOptions)0
+                                                                 range:NSMakeRange(0, string.length)
+                                                          withTemplate:@""];
     return string;
 }
 

--- a/Tests/xcnew-integration-tests/xcnew-integration-tests.sb
+++ b/Tests/xcnew-integration-tests/xcnew-integration-tests.sb
@@ -13,3 +13,4 @@
 (allow sysctl-read
     (sysctl-name "hw.pagesize" "hw.pagesize_compat")
     (sysctl-name "machdep.cpu.core_count"))
+(allow user-preference-write)

--- a/xcnew.xcodeproj/project.pbxproj
+++ b/xcnew.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		5B20AFC022F7437700EA7295 /* XCNProject.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B20AFBF22F7437700EA7295 /* XCNProject.m */; };
 		5B20AFC622F74B7300EA7295 /* XCNErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B20AFC522F74B7300EA7295 /* XCNErrors.m */; };
 		5B20AFCE22F7567C00EA7295 /* XCNOptionParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B20AFCD22F7567C00EA7295 /* XCNOptionParser.m */; };
+		5B2BA2792926BBB800D99B58 /* XCNSpamWarningSuppressor.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B2BA2772926B92900D99B58 /* XCNSpamWarningSuppressor.m */; };
 		5B2F804525FC95D20018752D /* XCNProject.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B20AFBF22F7437700EA7295 /* XCNProject.m */; };
 		5B35519423F5D75B000E5EA1 /* XCNLanguage.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B35519323F5D75B000E5EA1 /* XCNLanguage.m */; };
 		5B35519623F5D7C1000E5EA1 /* XCNUserInterface.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B35519523F5D7C1000E5EA1 /* XCNUserInterface.m */; };
@@ -129,6 +130,8 @@
 		5B20AFCC22F7567C00EA7295 /* XCNOptionParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCNOptionParser.h; sourceTree = "<group>"; };
 		5B20AFCD22F7567C00EA7295 /* XCNOptionParser.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCNOptionParser.m; sourceTree = "<group>"; };
 		5B20AFD522F7599700EA7295 /* XCNLanguage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCNLanguage.h; sourceTree = "<group>"; };
+		5B2BA2762926B92900D99B58 /* XCNSpamWarningSuppressor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCNSpamWarningSuppressor.h; sourceTree = "<group>"; };
+		5B2BA2772926B92900D99B58 /* XCNSpamWarningSuppressor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCNSpamWarningSuppressor.m; sourceTree = "<group>"; };
 		5B35519323F5D75B000E5EA1 /* XCNLanguage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCNLanguage.m; sourceTree = "<group>"; };
 		5B35519523F5D7C1000E5EA1 /* XCNUserInterface.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCNUserInterface.m; sourceTree = "<group>"; };
 		5B35519723F5D87C000E5EA1 /* XCNUserInterfaceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCNUserInterfaceTests.m; sourceTree = "<group>"; };
@@ -296,6 +299,8 @@
 				5B1FF6DF26140C61005136E4 /* Fixtures */,
 				5B1FF6AB2613F122005136E4 /* XCNFileHierarchyAssertions.h */,
 				5B1FF6AC2613F122005136E4 /* XCNFileHierarchyAssertions.m */,
+				5B2BA2762926B92900D99B58 /* XCNSpamWarningSuppressor.h */,
+				5B2BA2772926B92900D99B58 /* XCNSpamWarningSuppressor.m */,
 				5B1F0F3B22F7A2BA00A7AFFA /* XCNewTests.m */,
 				5BDE4A912490D8BE00292480 /* xcnew-integration-tests.sb */,
 				5B5364D52602D7D9007E7F20 /* Info.plist */,
@@ -567,6 +572,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B2BA2792926BBB800D99B58 /* XCNSpamWarningSuppressor.m in Sources */,
 				5B1FF6AD2613F122005136E4 /* XCNFileHierarchyAssertions.m in Sources */,
 				5B5364D42602D76C007E7F20 /* XCNewTests.m in Sources */,
 			);


### PR DESCRIPTION
- Suppress warnings about extension point
- Suppress warnings about Swift version
- Suppress errors about permission error to write xcassets
- Split out logic to suppress warnings
