### PR TITLE
Split out parameterized test case

### DIFF
--- a/Sources/xcnew/XCNErrors.m
+++ b/Sources/xcnew/XCNErrors.m
@@ -58,7 +58,7 @@ NSError *XCNErrorTemplateFactoryTimeoutWithTimeout(NSTimeInterval timeout) {
     return [NSError errorWithDomain:XCNErrorDomain code:XCNErrorTemplateFactoryTimeout userInfo:userInfo];
 }
 
-NSError *XCNErrorInvalidOptionWithCString(const char *longOption) {
+NSError *XCNErrorInvalidOptionWithCString(const char *longOption, BOOL missingArgument) {
     NSCParameterAssert(longOption != NULL);
     NSData *optionData = [NSData dataWithBytes:longOption length:strlen(longOption)];
     NSString *optionString;
@@ -67,7 +67,8 @@ NSError *XCNErrorInvalidOptionWithCString(const char *longOption) {
                                       NSStringEncodingDetectionUseOnlySuggestedEncodingsKey : @YES}
                     convertedString:&optionString
                 usedLossyConversion:nil];
-    NSDictionary *userInfo = @{NSLocalizedDescriptionKey : [NSString stringWithFormat:@"Unrecognized option '%@'.", optionString]};
+    NSString *format = missingArgument ? @"Missing argument for option '%@'." : @"Unrecognized option '%@'.";
+    NSDictionary *userInfo = @{NSLocalizedDescriptionKey : [NSString stringWithFormat:format, optionString]};
     return [NSError errorWithDomain:XCNErrorDomain code:XCNErrorInvalidOption userInfo:userInfo];
 }
 

--- a/Sources/xcnew/XCNErrorsInternal.h
+++ b/Sources/xcnew/XCNErrorsInternal.h
@@ -16,7 +16,7 @@ OBJC_EXPORT NSError *XCNErrorTemplateNotFoundWithKindIdentifier(NSString *templa
 OBJC_EXPORT NSError *XCNErrorTemplateFactoryNotFoundWithKindIdentifier(NSString *templateKindIdentifier);
 OBJC_EXPORT NSError *XCNErrorTemplateFactoryTimeoutWithTimeout(NSTimeInterval timeout);
 OBJC_EXPORT NSError *XCNErrorInvalidShortOptionWithCharacter(char shortOption);
-OBJC_EXPORT NSError *XCNErrorInvalidOptionWithCString(const char *longOption);
+OBJC_EXPORT NSError *XCNErrorInvalidOptionWithCString(const char *longOption, BOOL missingArgument);
 OBJC_EXPORT NSError *XCNErrorWrongNumberOfArgumentsWithRange(NSRange acceptableRange, int actual);
 
 NS_ASSUME_NONNULL_END

--- a/Sources/xcnew/XCNOptionParser.m
+++ b/Sources/xcnew/XCNOptionParser.m
@@ -83,6 +83,16 @@ static XCNOptionParser *_sharedOptionParser;
             case 'S':
                 lifecycle = XCNAppLifecycleSwiftUI;
                 break;
+            case ':':
+                /*
+                 * Although man pages of `getopt_long(3)` says "return `:' if there was a missing option argument and error messages are suppressed",
+                 * this behavior seems changed by defining `GNU_COMPATIBLE` flag at compile time.
+                 * So at least on macOS 12.5, `getopt_long(3)` never returns ':'.
+                 *
+                 * However, to be compatible with a future release of macOS, I put ':' label here and make it fall though.
+                 *
+                 * @see https://github.com/apple-oss-distributions/Libc/blob/7861c72b1692b65f79c03f21a8a1a8e51e14c843/stdlib/FreeBSD/getopt_long.c#L66
+                 */
             case '?':
                 if (error) {
                     const char *option = argv[optind - 1];

--- a/Tests/xcnew-tests/XCNErrorsTests.m
+++ b/Tests/xcnew-tests/XCNErrorsTests.m
@@ -54,8 +54,16 @@
     XCTAssertEqualObjects(error.localizedFailureReason, @"This error means Xcode changes interface to manipulate project files.");
 }
 
+- (void)testXCNErrorInvalidOptionWithCStringWithMissingArgument {
+    NSError *error = XCNErrorInvalidOptionWithCString("-i", YES);
+    XCTAssertEqualObjects(error.domain, XCNErrorDomain);
+    XCTAssertEqual(error.code, 6);
+    XCTAssertEqualObjects(error.localizedDescription, @"Missing argument for option '-i'.");
+    XCTAssertNil(error.localizedFailureReason);
+}
+
 - (void)testXCNErrorInvalidOptionWithCStringWithShortOption {
-    NSError *error = XCNErrorInvalidOptionWithCString("-X");
+    NSError *error = XCNErrorInvalidOptionWithCString("-X", NO);
     XCTAssertEqualObjects(error.domain, XCNErrorDomain);
     XCTAssertEqual(error.code, 6);
     XCTAssertEqualObjects(error.localizedDescription, @"Unrecognized option '-X'.");
@@ -63,7 +71,7 @@
 }
 
 - (void)testXCNErrorInvalidOptionWithCStringWithUnprintableShortOption {
-    NSError *error = XCNErrorInvalidOptionWithCString("-\x80");
+    NSError *error = XCNErrorInvalidOptionWithCString("-\x80", NO);
     XCTAssertEqualObjects(error.domain, XCNErrorDomain);
     XCTAssertEqual(error.code, 6);
     XCTAssertEqualObjects(error.localizedDescription, @"Unrecognized option '-\uFFFD'.");
@@ -71,7 +79,7 @@
 }
 
 - (void)testXCNErrorInvalidOptionWithCStringWithLongOption {
-    NSError *error = XCNErrorInvalidOptionWithCString("--invalid");
+    NSError *error = XCNErrorInvalidOptionWithCString("--invalid", NO);
     XCTAssertEqualObjects(error.domain, XCNErrorDomain);
     XCTAssertEqual(error.code, 6);
     XCTAssertEqualObjects(error.localizedDescription, @"Unrecognized option '--invalid'.");
@@ -79,7 +87,7 @@
 }
 
 - (void)testXCNErrorInvalidOptionWithCStringWithUTF8LongOption {
-    NSError *error = XCNErrorInvalidOptionWithCString("--日本語");
+    NSError *error = XCNErrorInvalidOptionWithCString("--日本語", NO);
     XCTAssertEqualObjects(error.domain, XCNErrorDomain);
     XCTAssertEqual(error.code, 6);
     XCTAssertEqualObjects(error.localizedDescription, @"Unrecognized option '--日本語'.");

--- a/Tests/xcnew-tests/XCNOptionParserParameterizedTests.m
+++ b/Tests/xcnew-tests/XCNOptionParserParameterizedTests.m
@@ -192,12 +192,23 @@ static NSArray<NSInvocation *> *_testInvocations;
                                   XCTAssertEqual(error.code, XCNErrorInvalidOption);
                                   XCTAssertTrue([error.localizedDescription containsString:@"-\uFFFD"]);
                               }],
+            // Missing argument
+            [self invocationWithArguments:@[ @"xcnew", @"-i" ]
+                              expectation:^(XCNOptionParseResult *result, NSString *output, NSError *error) {
+                                  XCTAssertNil(result);
+                                  XCTAssertEqualObjects(output, @"");
+                                  XCTAssertEqualObjects(error.domain, XCNErrorDomain);
+                                  XCTAssertEqual(error.code, XCNErrorInvalidOption);
+                                  XCTAssertTrue([error.localizedDescription containsString:@"Missing"]);
+                                  XCTAssertTrue([error.localizedDescription containsString:@"-i"]);
+                              }],
             [self invocationWithArguments:@[ @"xcnew", @"--organization-identifier" ]
                               expectation:^(XCNOptionParseResult *result, NSString *output, NSError *error) {
                                   XCTAssertNil(result);
                                   XCTAssertEqualObjects(output, @"");
                                   XCTAssertEqualObjects(error.domain, XCNErrorDomain);
                                   XCTAssertEqual(error.code, XCNErrorInvalidOption);
+                                  XCTAssertTrue([error.localizedDescription containsString:@"Missing"]);
                                   XCTAssertTrue([error.localizedDescription containsString:@"--organization-identifier"]);
                               }],
             // Reverse-ordered options

--- a/Tests/xcnew-tests/XCNOptionParserParameterizedTests.m
+++ b/Tests/xcnew-tests/XCNOptionParserParameterizedTests.m
@@ -248,35 +248,6 @@ static NSArray<NSInvocation *> *_testInvocations;
     close(_originalStandardOutputFileDescriptor);
 }
 
-- (void)testInheritance {
-    Class XCNSubclassedOptionParser = objc_allocateClassPair([XCNOptionParser class], "XCNSubclassedOptionParser", 0);
-    [self addTeardownBlock:^{
-        objc_disposeClassPair(XCNSubclassedOptionParser);
-    }];
-    objc_registerClassPair(XCNSubclassedOptionParser);
-    XCTAssertThrowsSpecificNamed([XCNSubclassedOptionParser self], NSException, NSInternalInconsistencyException);
-}
-
-- (void)testSomeInvalidShortOptionThrowsInvalidArgumentException {
-    XCTExpectFailure(@"getopt() always returns '?' when the short option is invalid so there's no chance for exception to be thrown.");
-    NSUInteger exceptionThrownCount = 0;
-    char shortOption[3] = "-?";
-    char *argv[3] = {"xcnew", shortOption, NULL};
-    for (char i = CHAR_MIN; i < CHAR_MAX; i++) {
-        shortOption[1] = i;
-        @try {
-            [XCNOptionParser.sharedOptionParser parseArguments:argv count:2 error:nil];
-        }
-        @catch (NSException *exception) {
-            if (exception.name != NSInvalidArgumentException) {
-                @throw exception;
-            }
-            exceptionThrownCount++;
-        }
-    }
-    XCTAssertGreaterThan(exceptionThrownCount, 0);
-}
-
 - (void)parameterizedTestParseArguments:(NSArray<NSString *> *)arguments expectation:(XCNOptionParserExpectation)expectationBlock {
     int argc = (int)arguments.count;
     char **argv = calloc(argc + 1, sizeof(char *));

--- a/Tests/xcnew-tests/XCNOptionParserParameterizedTests.m
+++ b/Tests/xcnew-tests/XCNOptionParserParameterizedTests.m
@@ -192,6 +192,14 @@ static NSArray<NSInvocation *> *_testInvocations;
                                   XCTAssertEqual(error.code, XCNErrorInvalidOption);
                                   XCTAssertTrue([error.localizedDescription containsString:@"-\uFFFD"]);
                               }],
+            [self invocationWithArguments:@[ @"xcnew", @"--organization-identifier" ]
+                              expectation:^(XCNOptionParseResult *result, NSString *output, NSError *error) {
+                                  XCTAssertNil(result);
+                                  XCTAssertEqualObjects(output, @"");
+                                  XCTAssertEqualObjects(error.domain, XCNErrorDomain);
+                                  XCTAssertEqual(error.code, XCNErrorInvalidOption);
+                                  XCTAssertTrue([error.localizedDescription containsString:@"--organization-identifier"]);
+                              }],
             // Reverse-ordered options
             [self invocationWithArguments:@[ @"xcnew", @"Example", @"-i", @"com.github.manicmaniac" ]
                               expectation:^(XCNOptionParseResult *result, NSString *output, NSError *error) {

--- a/Tests/xcnew-tests/XCNOptionParserParameterizedTests.m
+++ b/Tests/xcnew-tests/XCNOptionParserParameterizedTests.m
@@ -157,6 +157,7 @@ static NSArray<NSInvocation *> *_testInvocations;
                                   XCTAssertEqualObjects(output, @"");
                                   XCTAssertEqualObjects(error.domain, XCNErrorDomain);
                                   XCTAssertEqual(error.code, XCNErrorWrongNumberOfArgument);
+                                  XCTAssertTrue([error.localizedDescription containsString:@"0 for 1"]);
                               }],
             [self invocationWithArguments:@[ @"xcnew", @"-X" ]
                               expectation:^(XCNOptionParseResult *result, NSString *output, NSError *error) {
@@ -164,13 +165,32 @@ static NSArray<NSInvocation *> *_testInvocations;
                                   XCTAssertEqualObjects(output, @"");
                                   XCTAssertEqualObjects(error.domain, XCNErrorDomain);
                                   XCTAssertEqual(error.code, XCNErrorInvalidOption);
+                                  XCTAssertTrue([error.localizedDescription containsString:@"-X"]);
                               }],
-            [self invocationWithArguments:@[ @"xcnew", @"--invalid" ]
+            [self invocationWithArguments:@[ @"xcnew", @"--invalid", @"--help" ]
                               expectation:^(XCNOptionParseResult *result, NSString *output, NSError *error) {
                                   XCTAssertNil(result);
                                   XCTAssertEqualObjects(output, @"");
                                   XCTAssertEqualObjects(error.domain, XCNErrorDomain);
                                   XCTAssertEqual(error.code, XCNErrorInvalidOption);
+                                  XCTAssertTrue([error.localizedDescription containsString:@"--invalid"]);
+                              }],
+            [self invocationWithArguments:@[ @"xcnew", @"--日本語" ]
+                              expectation:^(XCNOptionParseResult *result, NSString *output, NSError *error) {
+                                  XCTAssertNil(result);
+                                  XCTAssertEqualObjects(output, @"");
+                                  XCTAssertEqualObjects(error.domain, XCNErrorDomain);
+                                  XCTAssertEqual(error.code, XCNErrorInvalidOption);
+                                  XCTAssertTrue([error.localizedDescription containsString:@"--日本語"]);
+                              }],
+            [self invocationWithArguments:@[ @"xcnew", @"--objc", @"-\uFFFD" ]
+                              expectation:^(XCNOptionParseResult *result, NSString *output, NSError *error) {
+                                  XCTExpectFailure(@"getopt() cannot treat non ASCII characters in options.");
+                                  XCTAssertNil(result);
+                                  XCTAssertEqualObjects(output, @"");
+                                  XCTAssertEqualObjects(error.domain, XCNErrorDomain);
+                                  XCTAssertEqual(error.code, XCNErrorInvalidOption);
+                                  XCTAssertTrue([error.localizedDescription containsString:@"-\uFFFD"]);
                               }],
             // Reverse-ordered options
             [self invocationWithArguments:@[ @"xcnew", @"Example", @"-i", @"com.github.manicmaniac" ]
@@ -217,20 +237,6 @@ static NSArray<NSInvocation *> *_testInvocations;
                                   XCTAssertNil(result);
                                   XCTAssertTrue([output containsString:version]);
                                   XCTAssertNil(error);
-                              }],
-            // Unicode characters
-            [self invocationWithArguments:@[ @"xcnew", @"-\uFFFD" ]
-                              expectation:^(XCNOptionParseResult *result, NSString *output, NSError *error) {
-                                  XCTAssertNil(result);
-                                  XCTAssertEqualObjects(output, @"");
-                                  XCTAssertEqual(error.code, XCNErrorInvalidOption);
-                              }],
-            [self invocationWithArguments:@[ @"xcnew", @"--日本語" ]
-                              expectation:^(XCNOptionParseResult *result, NSString *output, NSError *error) {
-                                  XCTAssertNil(result);
-                                  XCTAssertEqualObjects(output, @"");
-                                  XCTAssertEqual(error.code, XCNErrorInvalidOption);
-                                  XCTAssertTrue([error.localizedDescription containsString:@"--日本語"]);
                               }]
         ]];
     }

--- a/Tests/xcnew-tests/XCNOptionParserParameterizedTests.m
+++ b/Tests/xcnew-tests/XCNOptionParserParameterizedTests.m
@@ -217,6 +217,20 @@ static NSArray<NSInvocation *> *_testInvocations;
                                   XCTAssertNil(result);
                                   XCTAssertTrue([output containsString:version]);
                                   XCTAssertNil(error);
+                              }],
+            // Unicode characters
+            [self invocationWithArguments:@[ @"xcnew", @"-\uFFFD" ]
+                              expectation:^(XCNOptionParseResult *result, NSString *output, NSError *error) {
+                                  XCTAssertNil(result);
+                                  XCTAssertEqualObjects(output, @"");
+                                  XCTAssertEqual(error.code, XCNErrorInvalidOption);
+                              }],
+            [self invocationWithArguments:@[ @"xcnew", @"--日本語" ]
+                              expectation:^(XCNOptionParseResult *result, NSString *output, NSError *error) {
+                                  XCTAssertNil(result);
+                                  XCTAssertEqualObjects(output, @"");
+                                  XCTAssertEqual(error.code, XCNErrorInvalidOption);
+                                  XCTAssertTrue([error.localizedDescription containsString:@"--日本語"]);
                               }]
         ]];
     }

--- a/Tests/xcnew-tests/XCNOptionParserTests.m
+++ b/Tests/xcnew-tests/XCNOptionParserTests.m
@@ -26,24 +26,4 @@
     XCTAssertThrowsSpecificNamed([XCNSubclassedOptionParser self], NSException, NSInternalInconsistencyException);
 }
 
-- (void)testSomeInvalidShortOptionThrowsInvalidArgumentException {
-    XCTExpectFailure(@"getopt() always returns '?' when the short option is invalid so there's no chance for exception to be thrown.");
-    NSUInteger exceptionThrownCount = 0;
-    char shortOption[3] = "-?";
-    char *argv[3] = {"xcnew", shortOption, NULL};
-    for (char i = CHAR_MIN; i < CHAR_MAX; i++) {
-        shortOption[1] = i;
-        @try {
-            [XCNOptionParser.sharedOptionParser parseArguments:argv count:2 error:nil];
-        }
-        @catch (NSException *exception) {
-            if (exception.name != NSInvalidArgumentException) {
-                @throw exception;
-            }
-            exceptionThrownCount++;
-        }
-    }
-    XCTAssertGreaterThan(exceptionThrownCount, 0);
-}
-
 @end

--- a/Tests/xcnew-tests/XCNOptionParserTests.m
+++ b/Tests/xcnew-tests/XCNOptionParserTests.m
@@ -1,0 +1,49 @@
+//
+//  XCNOptionParserTests.m
+//  xcnew-tests
+//
+//  Created by Ryosuke Ito on 11/21/22.
+//  Copyright © 2022 Ryosuke Ito. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <objc/runtime.h>
+#import "XCNOptionParser.h"
+
+@interface XCNOptionParserTests : XCTestCase
+@end
+
+@implementation XCNOptionParserTests
+
+// MARK: Public
+
+- (void)testInheritance {
+    Class XCNSubclassedOptionParser = objc_allocateClassPair([XCNOptionParser class], "XCNSubclassedOptionParser", 0);
+    [self addTeardownBlock:^{
+        objc_disposeClassPair(XCNSubclassedOptionParser);
+    }];
+    objc_registerClassPair(XCNSubclassedOptionParser);
+    XCTAssertThrowsSpecificNamed([XCNSubclassedOptionParser self], NSException, NSInternalInconsistencyException);
+}
+
+- (void)testSomeInvalidShortOptionThrowsInvalidArgumentException {
+    XCTExpectFailure(@"getopt() always returns '?' when the short option is invalid so there's no chance for exception to be thrown.");
+    NSUInteger exceptionThrownCount = 0;
+    char shortOption[3] = "-?";
+    char *argv[3] = {"xcnew", shortOption, NULL};
+    for (char i = CHAR_MIN; i < CHAR_MAX; i++) {
+        shortOption[1] = i;
+        @try {
+            [XCNOptionParser.sharedOptionParser parseArguments:argv count:2 error:nil];
+        }
+        @catch (NSException *exception) {
+            if (exception.name != NSInvalidArgumentException) {
+                @throw exception;
+            }
+            exceptionThrownCount++;
+        }
+    }
+    XCTAssertGreaterThan(exceptionThrownCount, 0);
+}
+
+@end

--- a/xcnew.xcodeproj/project.pbxproj
+++ b/xcnew.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		5B39EAAB260BD5510028A910 /* XCNAppLifecycle.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B39EAAA260BD5510028A910 /* XCNAppLifecycle.m */; };
 		5B39EABB260BD67A0028A910 /* XCNAppLifecycle.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B39EAAA260BD5510028A910 /* XCNAppLifecycle.m */; };
 		5B39EAC2260C69AD0028A910 /* XCNAppLifecycleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B39EAC1260C69AD0028A910 /* XCNAppLifecycleTests.m */; };
+		5B4EAD2F292AE50E00398438 /* XCNOptionParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B4EAD2E292AE50E00398438 /* XCNOptionParserTests.m */; };
 		5B5364AF2602C915007E7F20 /* DVTFilePathTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BE75965260106EE00DC1E89 /* DVTFilePathTests.m */; };
 		5B5364C12602CBFD007E7F20 /* IDETemplateKindTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BE7596826010D8A00DC1E89 /* IDETemplateKindTests.m */; };
 		5B5364C22602CBFD007E7F20 /* IDETemplateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BE7596A26011AE600DC1E89 /* IDETemplateTests.m */; };
@@ -143,6 +144,7 @@
 		5B39EAAA260BD5510028A910 /* XCNAppLifecycle.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCNAppLifecycle.m; sourceTree = "<group>"; };
 		5B39EAC1260C69AD0028A910 /* XCNAppLifecycleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCNAppLifecycleTests.m; sourceTree = "<group>"; };
 		5B3F958023F55DB5002F32B8 /* XCNUserInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCNUserInterface.h; sourceTree = "<group>"; };
+		5B4EAD2E292AE50E00398438 /* XCNOptionParserTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCNOptionParserTests.m; sourceTree = "<group>"; };
 		5B5364A72602C8F8007E7F20 /* DVTFoundationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DVTFoundationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B5364B02602C957007E7F20 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5B5364B72602CB37007E7F20 /* IDEFoundationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IDEFoundationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -256,6 +258,7 @@
 				5B1F0F4A22F8515700A7AFFA /* XCNErrorsTests.m */,
 				5B35519B23F5D93A000E5EA1 /* XCNLanguageTests.m */,
 				5B6128262610F89000B048A1 /* XCNOptionParserParameterizedTests.m */,
+				5B4EAD2E292AE50E00398438 /* XCNOptionParserTests.m */,
 				5B7E89F225FC91A3004E0420 /* XCNProjectTests.m */,
 				5B35519723F5D87C000E5EA1 /* XCNUserInterfaceTests.m */,
 				5B1F0F3D22F7A2BA00A7AFFA /* Info.plist */,
@@ -524,6 +527,7 @@
 				5B1F0F4C22F8520000A7AFFA /* XCNErrors.m in Sources */,
 				5B61282D2610F8A300B048A1 /* XCNOptionParser.m in Sources */,
 				5B35519923F5D8FB000E5EA1 /* XCNUserInterface.m in Sources */,
+				5B4EAD2F292AE50E00398438 /* XCNOptionParserTests.m in Sources */,
 				5B35519A23F5D8FE000E5EA1 /* XCNLanguage.m in Sources */,
 				5B35519C23F5D93A000E5EA1 /* XCNLanguageTests.m in Sources */,
 				5B39EABB260BD67A0028A910 /* XCNAppLifecycle.m in Sources */,


### PR DESCRIPTION
- Isolate parameterized test cases
- Add test for unicode characters
- Remove obsolete test
- Improve test cases
- Handle no argument error
