### PR TITLE
Support Xcode 14.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: ["14.1.0", "14.0.1", "13.4.1", "13.3.1", "13.2.1", "13.1", "13.0", "12.5"]
+        xcode: ["14.2.0", "14.1.0", "14.0.1", "13.4.1", "13.3.1", "13.2.1", "13.1", "13.0", "12.5"]
         include:
+        - macos: macOS-12
+          xcode: "14.2.0"
         - macos: macOS-12
           xcode: "14.1.0"
         - macos: macOS-12

--- a/Frameworks/.versions
+++ b/Frameworks/.versions
@@ -1,7 +1,7 @@
 + xcodebuild -version
-Xcode 14.1
-Build version 14B47b
+Xcode 14.2
+Build version 14C18
 + class-dump --version
-class-dump 3.5-0.1.1 (64 bit) (forked by @manicmaniac) compiled Nov 18 2022 05:45:45
+class-dump 3.5-0.1.1 (64 bit) (forked by @manicmaniac) compiled Feb  1 2023 17:50:57
 + clang-format --version
-clang-format version 14.0.6
+clang-format version 15.0.7

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Usage
 Supported Xcode versions
 ------------------------
 
-`Xcode >= 12.5 && Xcode <= 14.1.0`.
+`Xcode >= 12.5 && Xcode <= 14.2.0`.
 
 How it works?
 -------------


### PR DESCRIPTION
Add Xcode 14.2.0 to test targets.

See https://developer.apple.com/documentation/xcode-release-notes for Xcode release notes.

This pull request is created by [`Update Xcode` workflow](https://github.com/manicmaniac/xcnew/blob/master/.github/workflows/update-xcode.yml).