### PR TITLE
distutils has been removed in Python 3.12

### DIFF
--- a/Package/Tests/Fixtures/__init__.py
+++ b/Package/Tests/Fixtures/__init__.py
@@ -1,11 +1,23 @@
-try:
-    from sysconfig import _parse_makefile as parse_makefile
-except ImportError:
-    from distutils.sysconfig import parse_makefile
 from functools import cached_property
 import pathlib
 import shlex
 
+try:
+    from distutils.sysconfig import parse_makefile
+except ImportError:
+    from sysconfig import _parse_makefile
+    from tempfile import NamedTemporaryFile
+
+    # https://github.com/python/cpython/blob/v3.11.7/Lib/distutils/sysconfig.py#L72
+    def parse_makefile(fn, g=None):
+        with open(fn, mode='rb') as src, NamedTemporaryFile() as dest:
+            data = src.read()
+            # `distutils.sysconfig.parse_makefile` understands escaped newlines
+            # but `sysconfig._parse_makefile` does not.
+            # The next line fills the gap by just replacing escaped newlines.
+            dest.write(data.replace(b'\\\n', b' '))
+            dest.seek(0)
+            return _parse_makefile(dest.name, g)
 
 _script_path = pathlib.Path(__file__)
 

--- a/Package/Tests/Fixtures/__init__.py
+++ b/Package/Tests/Fixtures/__init__.py
@@ -1,4 +1,7 @@
-from distutils.sysconfig import parse_makefile
+try:
+    from sysconfig import _parse_makefile as parse_makefile
+except ImportError:
+    from distutils.sysconfig import parse_makefile
 from functools import cached_property
 import pathlib
 import shlex


### PR DESCRIPTION
https://peps.python.org/pep-0632/
> distutils.sysconfig — use the sysconfig module
